### PR TITLE
Created a basic README to guide installations

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,0 +1,19 @@
+# mallard-ducktype
+Parser for the lightweight Ducktype syntax for Mallard
+
+## Install Ducktype
+
+Ducktype is Python-3-only, so to build and install:
+
+```
+python3 setup.py build
+sudo python3 setup.py install
+```
+
+Or to get the latest version uploaded to pypi:
+
+```
+virtualenv --python=python3 venv
+source venv/bin/activate
+pip-python3 install ducktype
+```

--- a/README.md
+++ b/README.md
@@ -15,5 +15,5 @@ Or to get the latest version uploaded to pypi:
 ```
 virtualenv --python=python3 venv
 source venv/bin/activate
-pip-python3 install ducktype
+pip-python3 install mallard-ducktype
 ```


### PR DESCRIPTION
People need to install the Ducktype parser before they can use it. We should show them how to do that.
