### PR TITLE
Output TAP from tests

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,5 +1,5 @@
 *~
-/__pycache__/
 /build/
 /dist/
 /ducktype.egg-info/
+__pycache__/

--- a/.gitignore
+++ b/.gitignore
@@ -2,4 +2,5 @@
 /build/
 /dist/
 /ducktype.egg-info/
+/tests/*.out
 __pycache__/

--- a/tests/runtests
+++ b/tests/runtests
@@ -1,13 +1,47 @@
 #!/bin/sh
 
+set -e
+set -u
+
+count=0
+any_failed=0
+
 for duck in *.duck; do
+    count=$(( count + 1 ))
+    out=$(echo $duck | sed -e 's/\.duck$/.out/')
     page=$(echo $duck | sed -e 's/\.duck$/.page/')
     error=$(echo $duck | sed -e 's/\.duck$/.error/')
+    fail=""
     if [ -f "$page" ]; then
-        python3 runtest.py $duck | cmp - $page || echo $duck
+        python3 runtest.py "$duck" > "$out" || fail="exit status $?"
+        if ! cmp "$out" "$page" >&2; then
+            fail="${fail:+${fail}, }unexpected output"
+            diff -u "$out" "$page" >&2 || :
+        fi
     elif [ -f "$error" ]; then
-        python3 runtest.py $duck | cmp - $error || echo $duck
+        status=0
+        python3 runtest.py "$duck" > "$out" || :
+        if ! cmp "$out" "$error" >&2; then
+            fail="unexpected error message"
+            diff -u "$out" "$error" >&2 || :
+        fi
     else
-        echo $duck;
+        fail="neither $page nor $error exists"
+    fi
+    if [ -z "$fail" ]; then
+        echo "ok $count - $duck"
+    else
+        any_failed=1
+        echo "not ok $count - $duck: $fail"
     fi
 done
+
+echo "1..$count"
+
+if [ "$any_failed" = 0 ]; then
+    echo "# All tests successful"
+else
+    echo "# At least one test failed"
+fi
+
+exit $any_failed


### PR DESCRIPTION
As far as I can see, this project's current test "API" is:

* `cd tests; ./runtests`
* Empty output (after some time) is success
* Non-empty output is a list of failed test-cases
* Exit status is nearly always 0 regardless

I've been looking at packaging this project for Debian and I'd like to replace that test "API" with something more suitable for automated build and test environments. [TAP](http://testanything.org/) seems like a good human/machine-readable text format for output, and I think it would also be helpful for the test script to exit with status != 0 on failure. Does that seem appropriate to you? (Or I can guard this behind a `--tap` command line option like GLib tests do, if you would prefer.)

This branch converts `runtests` to produce TAP and an exit status. On failure, it also diffs the expected vs. actual output so that failures can be diagnosed, which is useful in automated build/test environments where everything except the log is going to be discarded after the build/test finishes.